### PR TITLE
Check for nullable itemtypes

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ function processTag(type, item) {
     break;
   case 'itemprop':
     // console.log(i+" PROP => "+md5($(item).parents("[itemtype]").html())+" => "+$(item).attr('itemprop')+" from "+$(item).parents("[itemtype]").attr("itemtype"));
+    if($(item).parents("[itemtype]").html() == null){ return; }
     property    = $(item).attr('itemprop');
     value       = getPropValue(item);
     item_index  = arraySearch(items, md5($(item).parents("[itemtype]").html()));


### PR DESCRIPTION
Sometimes the sites you scrape are not that well formatted, this made it not break in my case.
The following URL is an example of where the scraping breaks (www.boozyshop.nl/real-techniques-real-techniques-sculpting-brush.html)